### PR TITLE
Fix terminal XSS and boolean check

### DIFF
--- a/ble.js
+++ b/ble.js
@@ -74,7 +74,7 @@ export class BLEDevice {
   }
 
   isConnected() {
-    return this.device && this.device.gatt.connected;
+    return !!(this.device && this.device.gatt && this.device.gatt.connected);
   }
 
   getDeviceName() {

--- a/ble.js
+++ b/ble.js
@@ -73,6 +73,9 @@ export class BLEDevice {
     });
   }
 
+  // Checks if the device is connected by verifying the presence of `this.device`,
+  // `this.device.gatt`, and `this.device.gatt.connected`. The `!!` operator ensures
+  // a boolean return value.
   isConnected() {
     return !!(this.device && this.device.gatt && this.device.gatt.connected);
   }

--- a/terminal.js
+++ b/terminal.js
@@ -15,7 +15,15 @@ export class Terminal {
 
     const line = document.createElement('div');
     line.className = `terminal-line ${type}`;
-    line.innerHTML = `<span class="timestamp">[${timestamp}]</span> ${message}`;
+
+    const timestampSpan = document.createElement('span');
+    timestampSpan.className = 'timestamp';
+    timestampSpan.textContent = `[${timestamp}]`;
+
+    const messageText = document.createTextNode(` ${message}`);
+
+    line.appendChild(timestampSpan);
+    line.appendChild(messageText);
     this.terminal.appendChild(line);
     this.terminal.scrollTop = this.terminal.scrollHeight;
   }


### PR DESCRIPTION
## Summary
- sanitize messages appended to the terminal to prevent HTML injection
- ensure `BLEDevice.isConnected()` always returns a boolean

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68411aa72e1c832b96a9890000b09be2