### PR TITLE
Add stopNotifications in BLE disconnect

### DIFF
--- a/ble.js
+++ b/ble.js
@@ -42,14 +42,24 @@ export class BLEDevice {
   }
 
   async disconnect() {
-    if (this.device && this.device.gatt.connected) {
-      await this.device.gatt.disconnect();
+    try {
+      if (this.txCharacteristic) {
+        await this.txCharacteristic.stopNotifications();
+      }
+
+      if (this.device && this.device.gatt.connected) {
+        await this.device.gatt.disconnect();
+      }
+    } catch (error) {
+      console.error('BLE Disconnect Error:', error);
+      throw error;
+    } finally {
+      this.device = null;
+      this.server = null;
+      this.service = null;
+      this.rxCharacteristic = null;
+      this.txCharacteristic = null;
     }
-    this.device = null;
-    this.server = null;
-    this.service = null;
-    this.rxCharacteristic = null;
-    this.txCharacteristic = null;
   }
 
   async send(data) {


### PR DESCRIPTION
## Summary
- gracefully stop BLE TX characteristic notifications on disconnect
- log disconnect errors like connect()

## Testing
- `bun x prettier --write ble.js`
- `bun x eslint .` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68411e08b924832bb5e06190b09cba0e