### PR TITLE
Fix grammar in Copilot docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 applyTo: "**"
 ---
 
-This project is intended for making connecting, logging including printing to screen and saving to file, and interacting with BLE devices that supports Nordic UART Service (NUS) easier than ever.
+This project is intended for making connecting, logging including printing to screen and saving to file, and interacting with BLE devices that support Nordic UART Service (NUS) easier than ever.
 
 ## General Coding Guidelines
 


### PR DESCRIPTION
## Summary
- fix grammar in `.github/copilot-instructions.md`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68411e08b624832bb2eb43cb554a0e1e