### PR TITLE
Fix duplicated prefixes in saved logs

### DIFF
--- a/terminal.js
+++ b/terminal.js
@@ -35,7 +35,15 @@ export class Terminal {
 
   async saveLogs() {
     const logText = this.logs
-      .map((log) => `[${log.timestamp}] ${log.type.toUpperCase()}: ${log.message}`)
+      .map((log) => {
+        const typeLabel = log.type.toUpperCase();
+        const prefix = `${log.type.charAt(0).toUpperCase() + log.type.slice(1)}: `;
+        let message = log.message;
+        if (message.startsWith(prefix)) {
+          message = message.slice(prefix.length);
+        }
+        return `[${log.timestamp}] ${typeLabel}: ${message}`;
+      })
       .join('\n');
 
     const blob = new Blob([logText], { type: 'text/plain' });

--- a/tests/terminal.test.js
+++ b/tests/terminal.test.js
@@ -18,3 +18,43 @@ test('Terminal clear removes logs and DOM nodes', () => {
   expect(terminal.logs.length).toBe(0);
   expect(terminalElement.innerHTML).toBe('');
 });
+
+test('Terminal saveLogs strips duplicate prefixes', async () => {
+  const dom = new JSDOM("<!DOCTYPE html><body><div id='terminal'></div></body>");
+  global.document = dom.window.document;
+
+  const originalBlob = global.Blob;
+  const originalCreate = global.URL.createObjectURL;
+  const originalRevoke = global.URL.revokeObjectURL;
+
+  const createdBlobs = [];
+  global.Blob = class {
+    constructor(parts, options) {
+      this.parts = parts;
+      this.options = options;
+      createdBlobs.push(this);
+    }
+  };
+  global.URL.createObjectURL = () => 'blob:mock';
+  global.URL.revokeObjectURL = () => {};
+
+  const terminalElement = dom.window.document.getElementById('terminal');
+  const terminal = new Terminal(terminalElement);
+
+  const ts = '2025-06-05T04:59:48.865Z';
+  terminal.logs = [
+    { timestamp: ts, message: 'Sent: stop_twai', type: 'sent' },
+    { timestamp: ts, message: 'Received: TWAI stop initiated', type: 'received' },
+  ];
+
+  await terminal.saveLogs();
+
+  expect(createdBlobs).toHaveLength(1);
+  expect(createdBlobs[0].parts[0]).toBe(
+    `[${ts}] SENT: stop_twai\n[${ts}] RECEIVED: TWAI stop initiated`
+  );
+
+  global.Blob = originalBlob;
+  global.URL.createObjectURL = originalCreate;
+  global.URL.revokeObjectURL = originalRevoke;
+});


### PR DESCRIPTION
## Summary
- clean up log entries when saving to file so the category isn't repeated
- add test covering log saving without duplicated prefixes

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_684126c94768832b811abf3e7d788702