### PR TITLE
Handle unexpected BLE disconnects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,10 +3,7 @@
     "browser": true,
     "es2021": true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:prettier/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**"
+applyTo: '**'
 ---
 
 This project is intended for making connecting, logging including printing to screen and saving to file, and interacting with BLE devices that support Nordic UART Service (NUS) easier than ever.

--- a/app.js
+++ b/app.js
@@ -6,6 +6,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const bleDevice = new BLEDevice();
   const terminal = new Terminal(document.getElementById('terminal'));
 
+  bleDevice.onDisconnected(() => {
+    onDisconnected();
+    terminal.print('Disconnected from device', 'info');
+  });
+
   // Get UI elements
   const connectBtn = document.getElementById('connectBtn');
   const disconnectBtn = document.getElementById('disconnectBtn');
@@ -36,8 +41,6 @@ document.addEventListener('DOMContentLoaded', () => {
   disconnectBtn.addEventListener('click', async () => {
     try {
       await bleDevice.disconnect();
-      onDisconnected();
-      terminal.print('Disconnected from device', 'info');
     } catch (error) {
       terminal.print('Disconnect failed: ' + error.message, 'error');
     }

--- a/ble.js
+++ b/ble.js
@@ -5,6 +5,8 @@ export class BLEDevice {
     this.service = null;
     this.rxCharacteristic = null;
     this.txCharacteristic = null;
+    this.disconnectCallbacks = [];
+    this._boundHandleDisconnection = this._handleDisconnection.bind(this);
     this.NUS_SERVICE_UUID = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
     this.RX_CHARACTERISTIC_UUID = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
     this.TX_CHARACTERISTIC_UUID = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
@@ -34,6 +36,9 @@ export class BLEDevice {
       // Start notifications
       await this.txCharacteristic.startNotifications();
 
+      // Listen for unexpected disconnections
+      this.device.addEventListener('gattserverdisconnected', this._boundHandleDisconnection);
+
       return true;
     } catch (error) {
       console.error('BLE Connection Error:', error);
@@ -54,11 +59,7 @@ export class BLEDevice {
       console.error('BLE Disconnect Error:', error);
       throw error;
     } finally {
-      this.device = null;
-      this.server = null;
-      this.service = null;
-      this.rxCharacteristic = null;
-      this.txCharacteristic = null;
+      this._handleDisconnection();
     }
   }
 
@@ -80,6 +81,29 @@ export class BLEDevice {
       const decoder = new TextDecoder();
       const value = decoder.decode(event.target.value);
       callback(value);
+    });
+  }
+
+  onDisconnected(callback) {
+    this.disconnectCallbacks.push(callback);
+  }
+
+  _handleDisconnection() {
+    if (this.device) {
+      this.device.removeEventListener('gattserverdisconnected', this._boundHandleDisconnection);
+    }
+    this.device = null;
+    this.server = null;
+    this.service = null;
+    this.rxCharacteristic = null;
+    this.txCharacteristic = null;
+
+    this.disconnectCallbacks.forEach((cb) => {
+      try {
+        cb();
+      } catch (err) {
+        console.error('Disconnect callback error:', err);
+      }
     });
   }
 

--- a/ble.js
+++ b/ble.js
@@ -105,6 +105,7 @@ export class BLEDevice {
         console.error('Disconnect callback error:', err);
       }
     });
+    this.disconnectCallbacks = [];
   }
 
   // Checks if the device is connected by verifying the presence of `this.device`,

--- a/index.html
+++ b/index.html
@@ -26,12 +26,7 @@
             <!-- Terminal output will appear here -->
           </div>
           <div class="input-area">
-            <input
-              type="text"
-              id="messageInput"
-              placeholder="Type your message..."
-              disabled
-            />
+            <input type="text" id="messageInput" placeholder="Type your message..." disabled />
             <button id="sendBtn" class="primary-btn" disabled>Send</button>
           </div>
           <div class="controls">

--- a/styles.css
+++ b/styles.css
@@ -21,8 +21,8 @@
 
 body {
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
+    'Helvetica Neue', sans-serif;
   line-height: 1.6;
   color: var(--text-color);
   background-color: var(--background-color);
@@ -66,7 +66,7 @@ header {
   padding: 1rem;
   border-radius: 4px;
   overflow-y: auto;
-  font-family: "Courier New", Courier, monospace;
+  font-family: 'Courier New', Courier, monospace;
   margin-bottom: 1rem;
 }
 
@@ -112,7 +112,7 @@ header {
   margin-bottom: 1rem;
 }
 
-input[type="text"] {
+input[type='text'] {
   flex: 1;
   padding: 0.5rem;
   border: 2px solid var(--secondary-color);

--- a/tests/ble.test.js
+++ b/tests/ble.test.js
@@ -1,0 +1,39 @@
+import { test, expect } from 'bun:test';
+import { BLEDevice } from '../ble.js';
+
+// Mock Bluetooth device for tests
+class MockDevice {
+  constructor() {
+    this.listeners = {};
+  }
+
+  addEventListener(event, cb) {
+    this.listeners[event] = cb;
+  }
+
+  removeEventListener(event, cb) {
+    if (this.listeners[event] === cb) {
+      delete this.listeners[event];
+    }
+  }
+
+  trigger(event) {
+    if (this.listeners[event]) {
+      this.listeners[event]();
+    }
+  }
+}
+
+test('onDisconnected callback is called on handleDisconnection', () => {
+  const ble = new BLEDevice();
+  ble.device = new MockDevice();
+  let called = false;
+  ble.onDisconnected(() => {
+    called = true;
+  });
+
+  ble._handleDisconnection();
+
+  expect(called).toBe(true);
+  expect(ble.device).toBe(null);
+});


### PR DESCRIPTION
## Summary
- handle unexpected BLE device disconnects
- update app logic to react to disconnect events
- keep Prettier happy and add a small BLE test

## Testing
- `npm run format:check --silent`
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68413ce3db1c832b982341220c963273